### PR TITLE
add jbang catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You'll find a short version below. [Read the doc](https://docs.jeamlit.io/get-st
 1. Install the CLI ([JBang](https://www.jbang.dev/) is highly recommended)
     ```bash
     # recommended: install with jbang
-    jbang app install io.jeamlit:jeamlit:0.44.0:all
+    jbang app install io.jeamlit:jeamlit:0.44.0:all@fatjar
 
     # vanilla
     curl -L -o jeamlit.jar https://repo1.maven.org/maven2/io/jeamlit/jeamlit/0.44.0/jeamlit-0.44.0-all.jar


### PR DESCRIPTION
this gives you `jbang jeamlit@jeamlit/jeamlit`

would recommend to create github.com/jeamlit/jbang-catalog repo instead and put this jbang-catalog.json in it instead because then it becomes `jbang jeamlit@jeamlit`

Also used @fatjar to avoid resolving all the transitive non-needed deps so the install should be much faster.