### PR TITLE
feat: add imageFromBase64 method for base64 image support(#55)

### DIFF
--- a/snippetFiles/Base64ImageApp.java
+++ b/snippetFiles/Base64ImageApp.java
@@ -1,0 +1,22 @@
+import io.javelit.core.Jt;
+
+public class Base64ImageApp {
+    public static void main(String[] args) {
+        // A small 10x10 red PNG image encoded as base64
+        // This is a minimal valid PNG that displays a solid red square
+        String base64Png = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mP8z8DwHwYYGBgYBhBHAQBVhQOBMN0vkwAAAABJRU5ErkJggg==";
+
+        Jt.title("Base64 Image Demo").use();
+        Jt.text("This image is loaded directly from a base64 string:").use();
+        Jt.imageFromBase64(base64Png)
+                .caption("A red square loaded from base64")
+                .use();
+
+        // Example with data URI prefix (also supported)
+        String base64WithPrefix = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mNk+M/wnwEJMDIyMgxgjgIAXjAJAZBRxZYAAAAASUVORK5CYII=";
+        Jt.text("This one includes the data URI prefix:").use();
+        Jt.imageFromBase64(base64WithPrefix)
+                .caption("A green square with data URI prefix")
+                .use();
+    }
+}

--- a/src/main/java/io/javelit/core/Jt.java
+++ b/src/main/java/io/javelit/core/Jt.java
@@ -70,15 +70,15 @@ import static com.google.common.base.Preconditions.checkState;
  * import io.javelit.core.Jt;
  *
  * public class MyApp {
- *     public static void main(String[] args) {
- *         Jt.title("Welcome").use();
- *         String name = Jt.textInput("Enter your name").use();
- *         if (Jt.button("Submit").use()) {
- *             Jt.text("Hello, " + name).use();
- *         }
+ *   public static void main(String[] args) {
+ *     Jt.title("Welcome").use();
+ *     String name = Jt.textInput("Enter your name").use();
+ *     if (Jt.button("Submit").use()) {
+ *       Jt.text("Hello, " + name).use();
  *     }
+ *   }
  * }
- *}
+ * }
  * <p>
  * Get the session state with {@link Jt#sessionState}.
  * Get the app cache with {@link Jt#cache}.
@@ -89,29 +89,34 @@ public final class Jt {
   public static final JtContainer SIDEBAR = JtContainer.SIDEBAR;
 
   /**
-   * Return the session state Map of the session. A session corresponds to an opened tab of the app.
+   * Return the session state Map of the session. A session corresponds to an
+   * opened tab of the app.
    * <p>
    * The session state is maintained across re-runs.
    * Values can be stored and persisted in this map.
    * <p>
    * Examples:
    * Basic counter with session state
-   * {@snippet file = "CounterApp.java" appUrl = "https://javelit-container-usfu-production.up.railway.app" appHeight = "300"}
+   * {@snippet file = "CounterApp.java" appUrl =
+   * "https://javelit-container-usfu-production.up.railway.app" appHeight = "300"}
    */
   public static TypedMap sessionState() {
     return StateManager.publicSessionState();
   }
 
   /**
-   * Return the components state of the session. A session corresponds to an opened tab of the app.
+   * Return the components state of the session. A session corresponds to an
+   * opened tab of the app.
    * <p>
    * The current value of any component can be obtained from this map.
-   * When putting a component in the app, us the {@code .key()} method to define a specific key that will be easy
+   * When putting a component in the app, us the {@code .key()} method to define a
+   * specific key that will be easy
    * to access from this map.
    * <p>
    * Examples:
    * Accessing component values by key
-   * {@snippet file = "ComponentsStateApp.java" appUrl = "https://javelit-container-qkdk-production.up.railway.app" appHeight = "300"}
+   * {@snippet file = "ComponentsStateApp.java" appUrl =
+   * "https://javelit-container-qkdk-production.up.railway.app" appHeight = "300"}
    */
   public static TypedMap componentsState() {
     return StateManager.publicComponentsState();
@@ -122,22 +127,31 @@ public final class Jt {
    * <p>
    * This method allows programmatic updating of component state. Limits:
    * <ul>
-   *     <li>You cannot modify the value of a component that has not been rendered with a {@code .key()} in the session yet.</li>
-   *     <li>You cannot modify the value of a component that has already been rendered in the current app run.</li>
+   * <li>You cannot modify the value of a component that has not been rendered
+   * with a {@code .key()} in the session yet.</li>
+   * <li>You cannot modify the value of a component that has already been rendered
+   * in the current app run.</li>
    * </ul>
-   * Learn more in the <a href="https://docs.javelit.io/develop/concepts/design/buttons#buttons-to-modify-or-reset-other-widgets">modify widget examples</a>.
+   * Learn more in the <a href=
+   * "https://docs.javelit.io/develop/concepts/design/buttons#buttons-to-modify-or-reset-other-widgets">modify
+   * widget examples</a>.
    * <p>
-   * This method validates that the provided value is of the correct type and respects constraints if any (for instance, value range).
+   * This method validates that the provided value is of the correct type and
+   * respects constraints if any (for instance, value range).
    * <p>
    * Examples:
    * Programmatically update a text input value
-   * {@snippet file = "UpdateStateApp.java" appUrl = "https://javelit-container-production-5b01.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "UpdateStateApp.java" appUrl =
+   * "https://javelit-container-production-5b01.up.railway.app/" appHeight =
+   * "300"}
    * <p>
    *
    * @param key   The key of the component (as set via {@code .key()})
    * @param value The new value to set
-   * @throws IllegalArgumentException if userKey is null or the provided key does not match an existing component
-   * @throws IllegalStateException    if component has already been rendered in the current execution
+   * @throws IllegalArgumentException if userKey is null or the provided key does
+   *                                  not match an existing component
+   * @throws IllegalStateException    if component has already been rendered in
+   *                                  the current execution
    * @throws ClassCastException       if value type does not match component type
    */
   public static void setComponentState(final @Nonnull String key, final @Nullable Object value) {
@@ -147,18 +161,24 @@ public final class Jt {
   /**
    * Return the app cache. The app cache is shared across all sessions.
    * Put values in this map that are meant to be shared across all users.
-   * For instance: database long-lived connections, ML models loaded weights, etc...
+   * For instance: database long-lived connections, ML models loaded weights,
+   * etc...
    * <p>
-   * See <a href="https://docs.javelit.io/get-started/fundamentals/advanced-concepts#caching">documentation</a>.
+   * See <a href=
+   * "https://docs.javelit.io/get-started/fundamentals/advanced-concepts#caching">documentation</a>.
    * <p>
    * Examples:
    * Caching expensive computations
-   * {@snippet file = "CacheApp.java" appUrl = "https://javelit-container-fyxu-production.up.railway.app" appHeight = "300"}
+   * {@snippet file = "CacheApp.java" appUrl =
+   * "https://javelit-container-fyxu-production.up.railway.app" appHeight = "300"}
    * <p>
    * Sharing data across users
-   * {@snippet file = "SharedDataApp.java" appUrl = "https://javelit-container-xrmg-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "SharedDataApp.java" appUrl =
+   * "https://javelit-container-xrmg-production.up.railway.app/" appHeight =
+   * "300"}
    * <p>
    * Deleting values in the cache:
+   * 
    * <pre>
    * {@code
    * // remove all values
@@ -167,14 +187,16 @@ public final class Jt {
    * Jt.cache().remove("my_key");
    * }
    * </pre>
-   * {@code TypedMap} simply extends the java {@code Map} type with quality-of-life
-   * casting methods like {@code getInt}, {@code getDouble}, {@code getString}, etc...
+   * 
+   * {@code TypedMap} simply extends the java {@code Map} type with
+   * quality-of-life
+   * casting methods like {@code getInt}, {@code getDouble}, {@code getString},
+   * etc...
    *
    */
   public static TypedMap cache() {
     return StateManager.getCache();
   }
-
 
   /**
    * Return the current url path.
@@ -184,7 +206,9 @@ public final class Jt {
    * <p>
    * Examples:
    * Conditional content based on current path
-   * {@snippet file = "PathApp.java" appUrl = "https://javelit-container-uflt-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "PathApp.java" appUrl =
+   * "https://javelit-container-uflt-production.up.railway.app/" appHeight =
+   * "300"}
    */
   public static String urlPath() {
     return StateManager.getUrlContext().currentPath();
@@ -198,7 +222,9 @@ public final class Jt {
    * <p>
    * Examples:
    * Using query parameters for app configuration
-   * {@snippet file = "QueryParamsApp.java" appUrl = "https://javelit-container-production-f57e.up.railway.app/?name=Alice" appHeight = "300"}
+   * {@snippet file = "QueryParamsApp.java" appUrl =
+   * "https://javelit-container-production-f57e.up.railway.app/?name=Alice"
+   * appHeight = "300"}
    */
   // TODO consider adding a TypedMap interface with list unwrap
   public static Map<String, List<String>> urlQueryParameters() {
@@ -208,13 +234,17 @@ public final class Jt {
   /**
    * Return a deep copy of the provided object.
    * <p>
-   * Utility that may be useful in combination with the cache, to implement a copy on read behavior.
+   * Utility that may be useful in combination with the cache, to implement a copy
+   * on read behavior.
    * For instance, you can get a value that is expensive to
-   * instantiate from the cache, but perform a deep copy to prevent mutations and side effects across sessions.
+   * instantiate from the cache, but perform a deep copy to prevent mutations and
+   * side effects across sessions.
    * <p>
    * Examples:
    * Safe copying from cache to prevent mutations
-   * {@snippet file = "DeepCopyApp.java" appUrl = "https://javelit-container-wlct-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "DeepCopyApp.java" appUrl =
+   * "https://javelit-container-wlct-production.up.railway.app/" appHeight =
+   * "300"}
    *
    * @return a deep copy of the provided object.
    */
@@ -231,7 +261,9 @@ public final class Jt {
    * Write text without Markdown or HTML parsing.
    * For monospace text, use {@link Jt#code}
    * Examples:
-   * {@snippet file = "TextExample.java" appUrl = "https://javelit-container-production-0e7a.up.railway.app/" appHeight = "250"}
+   * {@snippet file = "TextExample.java" appUrl =
+   * "https://javelit-container-production-0e7a.up.railway.app/" appHeight =
+   * "250"}
    *
    * @param body The string to display.
    */
@@ -241,13 +273,17 @@ public final class Jt {
 
   /**
    * Display text in title formatting.
-   * Each document should have a single {@code Jt.title()}, although this is not enforced.
+   * Each document should have a single {@code Jt.title()}, although this is not
+   * enforced.
    * <p>
    * Examples:
    * Basic title and title with markdown formatting and styling
-   * {@snippet file = "TitleApp.java" appUrl = "https://javelit-container-production-764a.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "TitleApp.java" appUrl =
+   * "https://javelit-container-production-764a.up.railway.app/" appHeight =
+   * "300"}
    *
-   * @param body The text to display. Markdown is supported, see {@link #markdown(String)} for more details.
+   * @param body The text to display. Markdown is supported, see
+   *             {@link #markdown(String)} for more details.
    */
   public static TitleComponent.Builder title(@Language("markdown") final @Nonnull String body) {
     return new TitleComponent.Builder(body, 1);
@@ -258,9 +294,12 @@ public final class Jt {
    * <p>
    * Examples:
    * Basic header and header with markdown formatting and styling
-   * {@snippet file = "HeaderApp.java" appUrl = "https://javelit-container-faea-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "HeaderApp.java" appUrl =
+   * "https://javelit-container-faea-production.up.railway.app/" appHeight =
+   * "300"}
    *
-   * @param body The text to display. Markdown is supported, see {@link #markdown(String)} for more details.
+   * @param body The text to display. Markdown is supported, see
+   *             {@link #markdown(String)} for more details.
    */
   public static TitleComponent.Builder header(@Language("markdown") final @Nonnull String body) {
     return new TitleComponent.Builder(body, 2);
@@ -271,9 +310,11 @@ public final class Jt {
    * <p>
    * Examples:
    * Basic subheader and subheader with markdown formatting and styling
-   * {@snippet file = "SubHeaderApp.java" appUrl = "https://javelit-container-jey-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "SubHeaderApp.java" appUrl =
+   * "https://javelit-container-jey-production.up.railway.app/" appHeight = "300"}
    *
-   * @param body The text to display. Markdown is supported, see {@link #markdown(String)} for more details.
+   * @param body The text to display. Markdown is supported, see
+   *             {@link #markdown(String)} for more details.
    */
   public static TitleComponent.Builder subheader(@Language("markdown") final @Nonnull String body) {
     return new TitleComponent.Builder(body, 3);
@@ -284,15 +325,20 @@ public final class Jt {
    * <p>
    * Supported :
    * <ul>
-   *     <li>Emoji shortcodes, such as {@code :+1:} and {@code :sunglasses:}. For a list of all supported codes, see <a href="https://www.webfx.com/tools/emoji-cheat-sheet/">https://www.webfx.com/tools/emoji-cheat-sheet/</a>.</li>
-   *     <li>Tables</li>
-   *     <li>Strikethrough</li>
-   *     <li>Autolink: turns plain links such as URLs and email addresses into links</li>
+   * <li>Emoji shortcodes, such as {@code :+1:} and {@code :sunglasses:}. For a
+   * list of all supported codes, see <a href=
+   * "https://www.webfx.com/tools/emoji-cheat-sheet/">https://www.webfx.com/tools/emoji-cheat-sheet/</a>.</li>
+   * <li>Tables</li>
+   * <li>Strikethrough</li>
+   * <li>Autolink: turns plain links such as URLs and email addresses into
+   * links</li>
    * </ul>
    * <p>
    * Examples:
    * Basic markdown formatting and colored text styling
-   * {@snippet file = "MarkdownApp.java" appUrl = "https://javelit-container-nlt3-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "MarkdownApp.java" appUrl =
+   * "https://javelit-container-nlt3-production.up.railway.app/" appHeight =
+   * "300"}
    *
    * @param body The text to display as Markdown.
    */
@@ -305,7 +351,8 @@ public final class Jt {
    * <p>
    * Examples:
    * Basic section separator
-   * {@snippet file = "DividerApp.java" appUrl = "https://javelit-container-hru4-production.up.railway.app" appHeight = "350"}
+   * {@snippet file = "DividerApp.java" appUrl =
+   * "https://javelit-container-hru4-production.up.railway.app" appHeight = "350"}
    */
   public static MarkdownComponent.Builder divider() {
     return new MarkdownComponent.Builder("---");
@@ -313,7 +360,8 @@ public final class Jt {
 
   /**
    * Display a horizontal rule.
-   * Deprecated. Use Jt.divider() instead. Passing unique keys is not necessary anymore.
+   * Deprecated. Use Jt.divider() instead. Passing unique keys is not necessary
+   * anymore.
    *
    * @param key A custom key.
    */
@@ -327,12 +375,16 @@ public final class Jt {
    * <p>
    * Examples:
    * Simple error message
-   * {@snippet file = "ErrorApp.java" appUrl = "https://javelit-container-mh0v-production.up.railway.app" appHeight = "300"}
+   * {@snippet file = "ErrorApp.java" appUrl =
+   * "https://javelit-container-mh0v-production.up.railway.app" appHeight = "300"}
    * <p>
    * Error with markdown formatting
-   * {@snippet file = "FormattedErrorApp.java" appUrl = "https://javelit-container-adrx-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "FormattedErrorApp.java" appUrl =
+   * "https://javelit-container-adrx-production.up.railway.app/" appHeight =
+   * "300"}
    *
-   * @param body The error text to display. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param body The error text to display. Markdown is supported, see
+   *             {@link Jt#markdown(String)} for more details.
    */
   public static CalloutComponent.Builder error(final @Language("markdown") @Nonnull String body) {
     return CalloutComponent.Builder.newError(body);
@@ -343,12 +395,16 @@ public final class Jt {
    * <p>
    * Examples:
    * Simple warning message
-   * {@snippet file = "WarningApp.java" appUrl = "https://javelit-container-2hya-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "WarningApp.java" appUrl =
+   * "https://javelit-container-2hya-production.up.railway.app/" appHeight =
+   * "300"}
    * <p>
    * Warning with markdown formatting
-   * {@snippet file = "FormattedWarningApp.java" appUrl = "https://javelit-container-n7e-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "FormattedWarningApp.java" appUrl =
+   * "https://javelit-container-n7e-production.up.railway.app/" appHeight = "300"}
    *
-   * @param body The warning text to display. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param body The warning text to display. Markdown is supported, see
+   *             {@link Jt#markdown(String)} for more details.
    */
   public static CalloutComponent.Builder warning(final @Language("markdown") @Nonnull String body) {
     return CalloutComponent.Builder.newWarning(body);
@@ -359,12 +415,17 @@ public final class Jt {
    * <p>
    * Examples:
    * Simple success message
-   * {@snippet file = "SuccessApp.java" appUrl = "https://javelit-container-util-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "SuccessApp.java" appUrl =
+   * "https://javelit-container-util-production.up.railway.app/" appHeight =
+   * "300"}
    * <p>
    * Success with markdown formatting
-   * {@snippet file = "FormattedSuccessApp.java" appUrl = "https://javelit-container-shmx-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "FormattedSuccessApp.java" appUrl =
+   * "https://javelit-container-shmx-production.up.railway.app/" appHeight =
+   * "300"}
    *
-   * @param body The success text to display. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param body The success text to display. Markdown is supported, see
+   *             {@link Jt#markdown(String)} for more details.
    */
   public static CalloutComponent.Builder success(final @Language("markdown") @Nonnull String body) {
     return CalloutComponent.Builder.newSuccess(body);
@@ -375,12 +436,17 @@ public final class Jt {
    * <p>
    * Examples:
    * Simple info message
-   * {@snippet file = "InfoApp.java" appUrl = "https://javelit-container-sfd2-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "InfoApp.java" appUrl =
+   * "https://javelit-container-sfd2-production.up.railway.app/" appHeight =
+   * "300"}
    * <p>
    * Info with markdown formatting
-   * {@snippet file = "FormattedInfoApp.java" appUrl = "https://javelit-container-o2ma-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "FormattedInfoApp.java" appUrl =
+   * "https://javelit-container-o2ma-production.up.railway.app/" appHeight =
+   * "300"}
    *
-   * @param body The info text to display. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param body The info text to display. Markdown is supported, see
+   *             {@link Jt#markdown(String)} for more details.
    */
   public static CalloutComponent.Builder info(final @Language("markdown") @Nonnull String body) {
     return CalloutComponent.Builder.newInfo(body);
@@ -390,14 +456,20 @@ public final class Jt {
    * Insert HTML into your app.
    * <p>
    * Adding custom HTML to your app impacts safety, styling, and maintainability.
-   * We sanitize HTML with <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, but inserting HTML remains a developer risk.
-   * Passing untrusted code to Jt.html or dynamically loading external code can increase the risk of vulnerabilities in your app.
+   * We sanitize HTML with
+   * <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, but inserting
+   * HTML remains a developer risk.
+   * Passing untrusted code to Jt.html or dynamically loading external code can
+   * increase the risk of vulnerabilities in your app.
    * <p>
-   * {@code Jt.html} content is not iframed. Executing JavaScript is not supported.
+   * {@code Jt.html} content is not iframed. Executing JavaScript is not
+   * supported.
    * <p>
    * Examples:
    * Simple HTML content
-   * {@snippet file = "HtmlApp.java" appUrl = "https://javelit-container-xqjt-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "HtmlApp.java" appUrl =
+   * "https://javelit-container-xqjt-production.up.railway.app/" appHeight =
+   * "300"}
    *
    * @param body The HTML code to insert.
    */
@@ -409,10 +481,14 @@ public final class Jt {
    * Insert HTML into your app.
    * <p>
    * Adding custom HTML to your app impacts safety, styling, and maintainability.
-   * We sanitize HTML with <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, but inserting HTML remains a developer risk.
-   * Passing untrusted code to Jt.html or dynamically loading external code can increase the risk of vulnerabilities in your app.
+   * We sanitize HTML with
+   * <a href="https://github.com/cure53/DOMPurify">DOMPurify</a>, but inserting
+   * HTML remains a developer risk.
+   * Passing untrusted code to Jt.html or dynamically loading external code can
+   * increase the risk of vulnerabilities in your app.
    * <p>
-   * {@code Jt.html} content is not iframed. Executing JavaScript is not supported.
+   * {@code Jt.html} content is not iframed. Executing JavaScript is not
+   * supported.
    * <p>
    * Examples:
    * Loading HTML from file
@@ -429,10 +505,13 @@ public final class Jt {
    * <p>
    * Examples:
    * Simple code block
-   * {@snippet file = "CodeApp.java" appUrl = "https://javelit-container-748i-production.up.railway.app" appHeight = "300"}
+   * {@snippet file = "CodeApp.java" appUrl =
+   * "https://javelit-container-748i-production.up.railway.app" appHeight = "300"}
    * <p>
    * Multi-line code with syntax highlighting
-   * {@snippet file = "MultilineCodeApp.java" appUrl = "https://javelit-container-lzvc-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "MultilineCodeApp.java" appUrl =
+   * "https://javelit-container-lzvc-production.up.railway.app/" appHeight =
+   * "300"}
    *
    * @param body The string to display as code or monospace text.
    */
@@ -445,9 +524,12 @@ public final class Jt {
    * <p>
    * Examples:
    * Basic button usage and interaction
-   * {@snippet file = "ButtonApp.java" appUrl = "https://javelit-container-p3l0-production.up.railway.app" appHeight = "300"}
+   * {@snippet file = "ButtonApp.java" appUrl =
+   * "https://javelit-container-p3l0-production.up.railway.app" appHeight = "300"}
    *
-   * @param label A short label explaining to the user what this button is for. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label A short label explaining to the user what this button is for.
+   *              Markdown is supported, see {@link Jt#markdown(String)} for more
+   *              details.
    */
   public static ButtonComponent.Builder button(@Language("markdown") final @Nonnull String label) {
     return new ButtonComponent.Builder(label);
@@ -458,9 +540,12 @@ public final class Jt {
    * <p>
    * Examples:
    * Basic checkbox usage
-   * {@snippet file = "CheckboxApp.java" appUrl = "https://javelit-container-dq4o-production.up.railway.app" appHeight = "300"}
+   * {@snippet file = "CheckboxApp.java" appUrl =
+   * "https://javelit-container-dq4o-production.up.railway.app" appHeight = "300"}
    *
-   * @param label A short label explaining to the user what this checkbox is for. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label A short label explaining to the user what this checkbox is for.
+   *              Markdown is supported, see {@link Jt#markdown(String)} for more
+   *              details.
    */
   public static CheckboxComponent.Builder checkbox(@Language("markdown") final @Nonnull String label) {
     return new CheckboxComponent.Builder(label);
@@ -471,12 +556,18 @@ public final class Jt {
    * <p>
    * Examples:
    * Simple toggle
-   * {@snippet file = "ToggleApp.java" appUrl = "https://javelit-container-nlsw-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "ToggleApp.java" appUrl =
+   * "https://javelit-container-nlsw-production.up.railway.app/" appHeight =
+   * "300"}
    * <p>
    * Toggle with default value
-   * {@snippet file = "ToggleDefaultApp.java" appUrl = "https://javelit-container-niog-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "ToggleDefaultApp.java" appUrl =
+   * "https://javelit-container-niog-production.up.railway.app/" appHeight =
+   * "300"}
    *
-   * @param label A short label explaining to the user what this toggle is for. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label A short label explaining to the user what this toggle is for.
+   *              Markdown is supported, see {@link Jt#markdown(String)} for more
+   *              details.
    */
   public static ToggleComponent.Builder toggle(@Language("markdown") final @Nonnull String label) {
     return new ToggleComponent.Builder(label);
@@ -487,9 +578,13 @@ public final class Jt {
    * <p>
    * Examples:
    * Basic integer slider usage
-   * {@snippet file = "SliderApp.java" appUrl = "https://javelit-container-ats7-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "SliderApp.java" appUrl =
+   * "https://javelit-container-ats7-production.up.railway.app/" appHeight =
+   * "300"}
    *
-   * @param label A short label explaining to the user what this slider is for. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label A short label explaining to the user what this slider is for.
+   *              Markdown is supported, see {@link Jt#markdown(String)} for more
+   *              details.
    */
   public static SliderComponent.Builder slider(@Language("markdown") final @Nonnull String label) {
     return new SliderComponent.Builder(label);
@@ -498,21 +593,26 @@ public final class Jt {
   /**
    * Insert a multi-element container.
    * <p>
-   * Insert an invisible container into your app that can be used to hold multiple elements.
-   * This allows you to, for example, insert multiple elements into your app out of order.
+   * Insert an invisible container into your app that can be used to hold multiple
+   * elements.
+   * This allows you to, for example, insert multiple elements into your app out
+   * of order.
    * <p>
    * To add elements to the returned container:
+   * 
    * <pre>
    * {@code
    * var container = Jt.container("container-1").use();
    * Jt.yourElement().use(container);
    * }
    * </pre>
+   * 
    * See examples below.
    * <p>
    * Examples:
    * Basic container usage and adding elements out of order
-   * {@snippet file = "ContainerApp.java" appUrl = "https://javelit-container-xdhp-production.up.railway.app" appHeight = "300"}
+   * {@snippet file = "ContainerApp.java" appUrl =
+   * "https://javelit-container-xdhp-production.up.railway.app" appHeight = "300"}
    *
    */
   public static ContainerComponent.Builder container() {
@@ -523,23 +623,28 @@ public final class Jt {
    * Insert a single-element container.
    * <p>
    * Insert a container into your app that can be used to hold a single element.
-   * This allows you to, for example, remove elements at any point, or replace several elements at once (using a child multi-element container).
+   * This allows you to, for example, remove elements at any point, or replace
+   * several elements at once (using a child multi-element container).
    * <p>
    * To insert/replace/clear an element on the returned container:
+   * 
    * <pre>
    * {@code
    * var container = Jt.empty("empty-1").use();
    * Jt.yourElement().use(container);
    * }
    * </pre>
+   * 
    * See examples below.
    * <p>
    * Examples:
    * Dynamic content replacement
-   * {@snippet file = "EmptyApp.java" appUrl = "https://javelit-container-cp9j-production.up.railway.app" appHeight = "400"}
+   * {@snippet file = "EmptyApp.java" appUrl =
+   * "https://javelit-container-cp9j-production.up.railway.app" appHeight = "400"}
    * <p>
    * Simple animations
-   * {@snippet file = "AnimationEmptyApp.java" appUrl = "https://javelit-container-production.up.railway.app" appHeight = "300"}
+   * {@snippet file = "AnimationEmptyApp.java" appUrl =
+   * "https://javelit-container-production.up.railway.app" appHeight = "300"}
    *
    */
   public static ContainerComponent.Builder empty() {
@@ -549,9 +654,11 @@ public final class Jt {
   /**
    * Insert containers laid out as side-by-side columns.
    * <p>
-   * Inserts a number of multi-element containers laid out side-by-side and returns a list of container objects.
+   * Inserts a number of multi-element containers laid out side-by-side and
+   * returns a list of container objects.
    * <p>
    * To add elements to the returned columns container:
+   * 
    * <pre>
    * {@code
    * var cols = Jt.columns("my-3-cols", 3).use();
@@ -560,11 +667,13 @@ public final class Jt {
    * Jt.yourElement().use(cols.col(2));
    * }
    * </pre>
+   * 
    * See examples below.
    * <p>
    * Examples:
    * Basic three-column layout with headers and content
-   * {@snippet file = "ColumnsApp.java" appUrl = "https://javelit-container-tnzd-production.up.railway.app" appHeight = "300"}
+   * {@snippet file = "ColumnsApp.java" appUrl =
+   * "https://javelit-container-tnzd-production.up.railway.app" appHeight = "300"}
    *
    * @param numColumns The number of columns to create
    */
@@ -576,9 +685,11 @@ public final class Jt {
    * Insert containers separated into tabs.
    * <p>
    * Inserts a number of multi-element containers as tabs.
-   * Tabs are a navigational element that allows users to easily move between groups of related content.
+   * Tabs are a navigational element that allows users to easily move between
+   * groups of related content.
    * <p>
    * To add elements to the returned tabs container:
+   * 
    * <pre>
    * {@code
    * var tabs = Jt.tabs("my-tabs", List.of("E-commerce", "Industry", "Finance")).use();
@@ -588,14 +699,18 @@ public final class Jt {
    * Jt.yourElement().use(tabs.tab(2));
    * }
    * </pre>
+   * 
    * See examples below.
    * <p>
    * Examples:
    * Basic tabbed interface
-   * {@snippet file = "TabsApp.java" appUrl = "https://javelit-container-ebco-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "TabsApp.java" appUrl =
+   * "https://javelit-container-ebco-production.up.railway.app/" appHeight =
+   * "300"}
    * <p>
    * Data analysis tabs
-   * {@snippet file = "DataTabsApp.java" appUrl = "https://javelit-container-7zqb-production.up.railway.app" appHeight = "300"}
+   * {@snippet file = "DataTabsApp.java" appUrl =
+   * "https://javelit-container-7zqb-production.up.railway.app" appHeight = "300"}
    *
    * @param tabs A list of tab labels
    */
@@ -606,21 +721,26 @@ public final class Jt {
   /**
    * Insert a multi-element container that can be expanded/collapsed.
    * <p>
-   * Insert a container into your app that can be used to hold multiple elements and can be expanded or collapsed by the user.
+   * Insert a container into your app that can be used to hold multiple elements
+   * and can be expanded or collapsed by the user.
    * When collapsed, all that is visible is the provided label.
    * <p>
    * To add elements to the returned expander:
+   * 
    * <pre>
    * {@code
    * var expander = Jt.expander("my-expander", "More details").use();
    * Jt.yourElement().use(expander);
    * }
    * </pre>
+   * 
    * See examples below.
    * <p>
    * Examples:
    * Basic expander with explanation content
-   * {@snippet file = "ExpanderApp.java" appUrl = "https://javelit-container-b8jy-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "ExpanderApp.java" appUrl =
+   * "https://javelit-container-b8jy-production.up.railway.app/" appHeight =
+   * "300"}
    *
    * @param label The label for the expander header
    */
@@ -631,26 +751,34 @@ public final class Jt {
   /**
    * Insert a popover container.
    * <p>
-   * Inserts a multi-element container as a popover. It consists of a button-like element and a container that opens when the button is clicked.
+   * Inserts a multi-element container as a popover. It consists of a button-like
+   * element and a container that opens when the button is clicked.
    * <p>
-   * Opening and closing the popover will not trigger a rerun. Interacting with widgets inside of an open popover will
-   * rerun the app while keeping the popover open. Clicking outside of the popover will close it.
+   * Opening and closing the popover will not trigger a rerun. Interacting with
+   * widgets inside of an open popover will
+   * rerun the app while keeping the popover open. Clicking outside of the popover
+   * will close it.
    * <p>
    * To add elements to the returned popover:
    * {@snippet :
    * var popover = Jt.popover("my-popover", "Advanced configuration").use();
    * Jt.yourElement().use(popover);
-   *}
+   * }
    * See examples below.
    * <p>
    * Examples:
    * Settings popover
-   * {@snippet file = "PopoverApp.java" appUrl = "https://javelit-container-kuvn-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "PopoverApp.java" appUrl =
+   * "https://javelit-container-kuvn-production.up.railway.app/" appHeight =
+   * "300"}
    * <p>
    * Help popover with information
-   * {@snippet file = "HelpPopoverApp.java" appUrl = "https://javelit-container-8mdm-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "HelpPopoverApp.java" appUrl =
+   * "https://javelit-container-8mdm-production.up.railway.app/" appHeight =
+   * "300"}
    *
-   * @param label The label for the popover button. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label The label for the popover button. Markdown is supported, see
+   *              {@link Jt#markdown(String)} for more details.
    */
   public static PopoverComponent.Builder popover(@Language("markdown") @Nonnull String label) {
     return new PopoverComponent.Builder(label);
@@ -659,10 +787,13 @@ public final class Jt {
   /**
    * Create a form that batches elements together with a 'Submit' button.
    * <p>
-   * A form is a container that visually groups other elements and widgets together, and contains a Submit button.
-   * When the form's Submit button is pressed, all widget values inside the form will be sent to Javelit in a batch.
+   * A form is a container that visually groups other elements and widgets
+   * together, and contains a Submit button.
+   * When the form's Submit button is pressed, all widget values inside the form
+   * will be sent to Javelit in a batch.
    * <p>
    * To add elements to the form:
+   * 
    * <pre>
    * {@code
    * var form = Jt.form("my-form-1").use();
@@ -674,18 +805,25 @@ public final class Jt {
    * <p>
    * Forms have a few constraints:
    * <ul>
-   *     <li>Every form must contain a {@code Jt.formSubmitButton)}</li>
-   *     <li>{@code Jt.button} and {@code Jt.downloadButton} cannot be added to a form</li>
-   *     <li>Forms can appear anywhere in your app (sidebar, columns, etc), but they cannot be embedded inside other forms</li>
-   *     <li>Within a form, the only widget that can have a callback function is {@code Jt.formSubmitButton)}</li>
+   * <li>Every form must contain a {@code Jt.formSubmitButton)}</li>
+   * <li>{@code Jt.button} and {@code Jt.downloadButton} cannot be added to a
+   * form</li>
+   * <li>Forms can appear anywhere in your app (sidebar, columns, etc), but they
+   * cannot be embedded inside other forms</li>
+   * <li>Within a form, the only widget that can have a callback function is
+   * {@code Jt.formSubmitButton)}</li>
    * </ul>
    * <p>
    * Examples:
    * User registration form
-   * {@snippet file = "FormApp.java" appUrl = "https://javelit-container-ovom-production.up.railway.app/" appHeight = "510"}
+   * {@snippet file = "FormApp.java" appUrl =
+   * "https://javelit-container-ovom-production.up.railway.app/" appHeight =
+   * "510"}
    * <p>
    * Survey form
-   * {@snippet file = "SurveyFormApp.java" appUrl = "https://javelit-container-isdo-production.up.railway.app/" appHeight = "550"}
+   * {@snippet file = "SurveyFormApp.java" appUrl =
+   * "https://javelit-container-isdo-production.up.railway.app/" appHeight =
+   * "550"}
    *
    */
   public static FormComponent.Builder form() {
@@ -695,16 +833,22 @@ public final class Jt {
   /**
    * Display a form submit button.
    * <p>
-   * When clicked, all widget values inside the form will be sent from the user's browser to the Javelit server in a batch.
+   * When clicked, all widget values inside the form will be sent from the user's
+   * browser to the Javelit server in a batch.
    * <p>
-   * Every form must have at least one {@code Jt.formSubmitButton}. A {@code Jt.formSubmitButton} cannot exist outside a form.
+   * Every form must have at least one {@code Jt.formSubmitButton}. A
+   * {@code Jt.formSubmitButton} cannot exist outside a form.
    * <p>
    * Examples:
    * Basic form submit button
-   * {@snippet file = "FormSubmitApp.java" appUrl = "https://javelit-container-bq0o-production.up.railway.app/" appHeight = "450"}
+   * {@snippet file = "FormSubmitApp.java" appUrl =
+   * "https://javelit-container-bq0o-production.up.railway.app/" appHeight =
+   * "450"}
    * <p>
    * Multiple submit buttons in same form
-   * {@snippet file = "MultiSubmitApp.java" appUrl = "https://javelit-container-wdwc-production.up.railway.app/" appHeight = "490"}
+   * {@snippet file = "MultiSubmitApp.java" appUrl =
+   * "https://javelit-container-wdwc-production.up.railway.app/" appHeight =
+   * "490"}
    *
    * @param label The text to display on the submit button
    */
@@ -717,12 +861,18 @@ public final class Jt {
    * <p>
    * Examples:
    * Simple text input
-   * {@snippet file = "TextInputApp.java" appUrl = "https://javelit-container-lyjk-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "TextInputApp.java" appUrl =
+   * "https://javelit-container-lyjk-production.up.railway.app/" appHeight =
+   * "300"}
    * <p>
    * Text input with validation
-   * {@snippet file = "ValidatedTextInputApp.java" appUrl = "https://javelit-container-fh90-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "ValidatedTextInputApp.java" appUrl =
+   * "https://javelit-container-fh90-production.up.railway.app/" appHeight =
+   * "300"}
    *
-   * @param label A short label explaining to the user what this input is for. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label A short label explaining to the user what this input is for.
+   *              Markdown is supported, see {@link Jt#markdown(String)} for more
+   *              details.
    */
   public static TextInputComponent.Builder textInput(@Language("markdown") final @Nonnull String label) {
     return new TextInputComponent.Builder(label);
@@ -733,25 +883,34 @@ public final class Jt {
    * <p>
    * Examples:
    * Simple text area
-   * {@snippet file = "TextAreaApp.java" appUrl = "https://javelit-container-oyie-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "TextAreaApp.java" appUrl =
+   * "https://javelit-container-oyie-production.up.railway.app/" appHeight =
+   * "300"}
    * <p>
    * Text area for code input
-   * {@snippet file = "CodeTextAreaApp.java" appUrl = "https://javelit-container-e8he-production.up.railway.app" appHeight = "500"}
+   * {@snippet file = "CodeTextAreaApp.java" appUrl =
+   * "https://javelit-container-e8he-production.up.railway.app" appHeight = "500"}
    *
-   * @param label A short label explaining to the user what this input is for. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label A short label explaining to the user what this input is for.
+   *              Markdown is supported, see {@link Jt#markdown(String)} for more
+   *              details.
    */
   public static TextAreaComponent.Builder textArea(@Language("markdown") final @Nonnull String label) {
     return new TextAreaComponent.Builder(label);
   }
 
   /**
-   * Display a date input widget that can be configured to accept a single date or a date range.
+   * Display a date input widget that can be configured to accept a single date or
+   * a date range.
    * <p>
    * Examples:
    * Simple date input
-   * {@snippet file = "DateInputApp.java" appUrl = "https://javelit-container-hiol-production.up.railway.app" appHeight = "300"}
+   * {@snippet file = "DateInputApp.java" appUrl =
+   * "https://javelit-container-hiol-production.up.railway.app" appHeight = "300"}
    *
-   * @param label A short label explaining to the user what this date input is for. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label A short label explaining to the user what this date input is
+   *              for. Markdown is supported, see {@link Jt#markdown(String)} for
+   *              more details.
    */
   public static DateInputComponent.Builder dateInput(@Language("markdown") final @Nonnull String label) {
     return new DateInputComponent.Builder(label);
@@ -762,9 +921,13 @@ public final class Jt {
    * <p>
    * Examples:
    * Simple number input
-   * {@snippet file = "NumberInputApp.java" appUrl = "https://javelit-container-yrri-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "NumberInputApp.java" appUrl =
+   * "https://javelit-container-yrri-production.up.railway.app/" appHeight =
+   * "300"}
    *
-   * @param label A short label explaining to the user what this numeric input is for. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label A short label explaining to the user what this numeric input is
+   *              for. Markdown is supported, see {@link Jt#markdown(String)} for
+   *              more details.
    */
   public static NumberInputComponent.Builder<Number> numberInput(@Language("markdown") final @Nonnull String label) {
     return new NumberInputComponent.Builder<>(label);
@@ -775,13 +938,18 @@ public final class Jt {
    * <p>
    * Examples:
    * Integer input with specific type
-   * {@snippet file = "TypedNumberInputApp.java" appUrl = "https://javelit-container-qcrg-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "TypedNumberInputApp.java" appUrl =
+   * "https://javelit-container-qcrg-production.up.railway.app/" appHeight =
+   * "300"}
    *
-   * @param label      A short label explaining to the user what this numeric input is for. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label      A short label explaining to the user what this numeric
+   *                   input is for. Markdown is supported, see
+   *                   {@link Jt#markdown(String)} for more details.
    * @param valueClass The number type class (Integer, Double, Float, etc.)
    */
-  public static <T extends Number> NumberInputComponent.Builder<T> numberInput(@Language("markdown") final @Nonnull String label,
-                                                                               final Class<T> valueClass) {
+  public static <T extends Number> NumberInputComponent.Builder<T> numberInput(
+      @Language("markdown") final @Nonnull String label,
+      final Class<T> valueClass) {
     return new NumberInputComponent.Builder<>(label, valueClass);
   }
 
@@ -790,16 +958,22 @@ public final class Jt {
    * <p>
    * Examples:
    * Simple radio selection
-   * {@snippet file = "RadioApp.java" appUrl = "https://javelit-container-jo9r-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "RadioApp.java" appUrl =
+   * "https://javelit-container-jo9r-production.up.railway.app/" appHeight =
+   * "300"}
    * <p>
    * Radio with custom objects
-   * {@snippet file = "ProductRadioApp.java" appUrl = "https://javelit-container-hh-u-production.up.railway.app/" appHeight = "350"}
+   * {@snippet file = "ProductRadioApp.java" appUrl =
+   * "https://javelit-container-hh-u-production.up.railway.app/" appHeight =
+   * "350"}
    *
-   * @param label   A short label explaining to the user what this radio selection is for. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label   A short label explaining to the user what this radio selection
+   *                is for. Markdown is supported, see {@link Jt#markdown(String)}
+   *                for more details.
    * @param options The list of options to choose from
    */
   public static <T> RadioComponent.Builder<T> radio(@Language("markdown") final @Nonnull String label,
-                                                    final @Nonnull List<T> options) {
+      final @Nonnull List<T> options) {
     return new RadioComponent.Builder<>(label, options);
   }
 
@@ -808,26 +982,32 @@ public final class Jt {
    * <p>
    * Examples:
    * Simple dropdown selection
-   * {@snippet file = "SelectBoxApp.java" appUrl = "https://javelit-container-ydef-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "SelectBoxApp.java" appUrl =
+   * "https://javelit-container-ydef-production.up.railway.app/" appHeight =
+   * "300"}
    * <p>
    * Dropdown with default value
-   * {@snippet file = "ProcessingSelectBoxApp.java" appUrl = "https://javelit-container-vyft-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "ProcessingSelectBoxApp.java" appUrl =
+   * "https://javelit-container-vyft-production.up.railway.app/" appHeight =
+   * "300"}
    *
-   * @param label   A short label explaining to the user what this selection is for. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label   A short label explaining to the user what this selection is
+   *                for. Markdown is supported, see {@link Jt#markdown(String)}
+   *                for more details.
    * @param options The list of options to choose from
    * @param <T>     The type of the options
    */
   public static <T> SelectBoxComponent.Builder<T> selectbox(@Language("markdown") final @Nonnull String label,
-                                                            final @Nonnull List<T> options) {
+      final @Nonnull List<T> options) {
     return new SelectBoxComponent.Builder<>(label, options);
   }
 
   public static JtPage.Builder page(final @Nonnull Class<?> pageApp) {
     final String simpleName = pageApp.getSimpleName();
     throw new RuntimeException("""
-                                   Sorry, this method is not supported anymore. Use page(String path, JtRunnable page) instead. \s
-                                   To quickfix: replace `Jt.page(%s.class)` with `Jt.page("/%s", %s::main)`
-                                   """.formatted(simpleName, pageApp.getSimpleName(), pageApp.getSimpleName()));
+        Sorry, this method is not supported anymore. Use page(String path, JtRunnable page) instead. \s
+        To quickfix: replace `Jt.page(%s.class)` with `Jt.page("/%s", %s::main)`
+        """.formatted(simpleName, pageApp.getSimpleName(), pageApp.getSimpleName()));
   }
 
   /**
@@ -835,7 +1015,9 @@ public final class Jt {
    * <p>
    * Examples:
    * Basic page creation with custom title and icon
-   * {@snippet file = "NavigationApp.java" appUrl = "https://javelit-container-ygun-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "NavigationApp.java" appUrl =
+   * "https://javelit-container-ygun-production.up.railway.app/" appHeight =
+   * "300"}
    *
    * @param path The url path where the page should be found
    * @param page The page app logic
@@ -847,18 +1029,24 @@ public final class Jt {
   /**
    * Create a navigation component with multiple pages to create a multipage app.
    * <p>
-   * Call {@code Jt.navigation} in your entrypoint app class to define the available pages in your app.
+   * Call {@code Jt.navigation} in your entrypoint app class to define the
+   * available pages in your app.
    * {@code Jt.navigation} use() returns the current page.
    * <p>
-   * When using {@code Jt.navigation}, your entrypoint app class acts like a frame of common elements around each of your pages.
+   * When using {@code Jt.navigation}, your entrypoint app class acts like a frame
+   * of common elements around each of your pages.
    * <p>
-   * The set of available pages can be updated with each rerun for dynamic navigation.
-   * By default, {@code Jt.navigation} displays the available pages in the sidebar if there is more than one page.
+   * The set of available pages can be updated with each rerun for dynamic
+   * navigation.
+   * By default, {@code Jt.navigation} displays the available pages in the sidebar
+   * if there is more than one page.
    * This behavior can be changed using the {@code position} builder method.
    * <p>
    * Examples:
    * Basic multipage navigation setup
-   * {@snippet file = "NavigationApp.java" appUrl = "https://javelit-container-ygun-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "NavigationApp.java" appUrl =
+   * "https://javelit-container-ygun-production.up.railway.app/" appHeight =
+   * "300"}
    *
    * @param pages The pages to include in the navigation
    */
@@ -869,18 +1057,25 @@ public final class Jt {
   /**
    * Display a link to another page in a multipage app or to an external page.
    * <p>
-   * If another page in a multipage app is specified, clicking the {@code Jt.pageLink} element stops the current page execution
-   * and runs the specified page as if the user clicked on it in the sidebar navigation.
+   * If another page in a multipage app is specified, clicking the
+   * {@code Jt.pageLink} element stops the current page execution
+   * and runs the specified page as if the user clicked on it in the sidebar
+   * navigation.
    * <p>
-   * If an external page is specified, clicking the {@code Jt.pageLink} element opens a new tab to the specified page.
+   * If an external page is specified, clicking the {@code Jt.pageLink} element
+   * opens a new tab to the specified page.
    * The current script run will continue if not complete.
    * <p>
    * Examples:
    * A multipage app with the sidebar hidden.
-   * A footer replaces the sidebar. The footer contains links to all pages of the app and an external link.
-   * {@snippet file = "PageLinkApp.java" appUrl = "https://javelit-container-hgr7-production.up.railway.app/" appHeight = "300"}
+   * A footer replaces the sidebar. The footer contains links to all pages of the
+   * app and an external link.
+   * {@snippet file = "PageLinkApp.java" appUrl =
+   * "https://javelit-container-hgr7-production.up.railway.app/" appHeight =
+   * "300"}
    *
-   * @param pagePath The path of the page to link to in a multipage app. If null, target the home page.
+   * @param pagePath The path of the page to link to in a multipage app. If null,
+   *                 target the home page.
    */
   public static PageLinkComponent.Builder pageLink(final @jakarta.annotation.Nullable String pagePath) {
     return new PageLinkComponent.Builder(pagePath);
@@ -889,17 +1084,21 @@ public final class Jt {
   /**
    * Display a link to another page in a multipage app or to an external page.
    * <p>
-   * If another page in a multipage app is specified, clicking the {@code Jt.pageLink} element stops the current page execution
-   * and runs the specified page as if the user clicked on it in the sidebar navigation.
+   * If another page in a multipage app is specified, clicking the
+   * {@code Jt.pageLink} element stops the current page execution
+   * and runs the specified page as if the user clicked on it in the sidebar
+   * navigation.
    * <p>
-   * If an external page is specified, clicking the {@code Jt.pageLink} element opens a new tab to the specified page.
+   * If an external page is specified, clicking the {@code Jt.pageLink} element
+   * opens a new tab to the specified page.
    * The current script run will continue if not complete.
    *
    * @param url   The URL to link to
-   * @param label The text to display for the link. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label The text to display for the link. Markdown is supported, see
+   *              {@link Jt#markdown(String)} for more details.
    */
   public static PageLinkComponent.Builder pageLink(final @Nonnull String url,
-                                                   final @Language("markdown") @Nonnull String label) {
+      final @Language("markdown") @Nonnull String label) {
     return new PageLinkComponent.Builder(url, label);
   }
 
@@ -908,9 +1107,12 @@ public final class Jt {
    * <p>
    * Examples:
    * Basic file upload with processing
-   * {@snippet file = "FileUploadApp.java" appUrl = "https://javelit-container-ala-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "FileUploadApp.java" appUrl =
+   * "https://javelit-container-ala-production.up.railway.app/" appHeight = "300"}
    *
-   * @param label A short label explaining to the user what this file uploader is for. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label A short label explaining to the user what this file uploader is
+   *              for. Markdown is supported, see {@link Jt#markdown(String)} for
+   *              more details.
    */
   public static FileUploaderComponent.Builder fileUploader(@Language("markdown") final @Nonnull String label) {
     return new FileUploaderComponent.Builder(label);
@@ -918,11 +1120,14 @@ public final class Jt {
 
   /**
    * Display a chart using ECharts library.
-   * See <a href="https://echarts.icepear.org/" target="_blank">echarts-java documentation</a> for more info.
+   * See <a href="https://echarts.icepear.org/" target="_blank">echarts-java
+   * documentation</a> for more info.
    * <p>
    * Examples:
    * Plot from a {@code Chart} ({@code Bar} extends {@code Chart}).
-   * {@snippet file = "BarChartApp.java" appUrl = "https://javelit-container-8pdg-production.up.railway.app/" appHeight = "500"}
+   * {@snippet file = "BarChartApp.java" appUrl =
+   * "https://javelit-container-8pdg-production.up.railway.app/" appHeight =
+   * "500"}
    *
    * @param chart The ECharts {@code Chart} object to display
    */
@@ -932,11 +1137,14 @@ public final class Jt {
 
   /**
    * Display a chart using ECharts library.
-   * See <a href="https://echarts.icepear.org/" target="_blank">echarts-java documentation</a> for more info.
+   * See <a href="https://echarts.icepear.org/" target="_blank">echarts-java
+   * documentation</a> for more info.
    * <p>
    * Examples:
    * Plot from an {@code Option}.
-   * {@snippet file = "OptionChartApp.java" appUrl = "https://javelit-container-hqjs-production.up.railway.app/" appHeight = "500"}
+   * {@snippet file = "OptionChartApp.java" appUrl =
+   * "https://javelit-container-hqjs-production.up.railway.app/" appHeight =
+   * "500"}
    *
    * @param chartOption The ECharts {@code Option} object to display
    */
@@ -946,11 +1154,14 @@ public final class Jt {
 
   /**
    * Display a chart using ECharts library.
-   * See <a href="https://echarts.icepear.org/" target="_blank">echarts-java documentation</a> for more info.
+   * See <a href="https://echarts.icepear.org/" target="_blank">echarts-java
+   * documentation</a> for more info.
    * <p>
    * Examples:
    * Plot from a JSON {@code String}
-   * {@snippet file = "OptionJsonChartApp.java" appUrl = "https://javelit-container-n71a-production.up.railway.app/" appHeight = "500"}
+   * {@snippet file = "OptionJsonChartApp.java" appUrl =
+   * "https://javelit-container-n71a-production.up.railway.app/" appHeight =
+   * "500"}
    *
    * @param chartOptionJson The ECharts option as a JSON string
    */
@@ -963,7 +1174,9 @@ public final class Jt {
    * <p>
    * Examples:
    * Basic table with data objects
-   * {@snippet file = "TableApp.java" appUrl = "https://javelit-container-m0nf-production.up.railway.app/" appHeight = "400"}
+   * {@snippet file = "TableApp.java" appUrl =
+   * "https://javelit-container-m0nf-production.up.railway.app/" appHeight =
+   * "400"}
    *
    * @param rows The list of objects representing table rows
    */
@@ -974,7 +1187,8 @@ public final class Jt {
   /**
    * Display a static table.
    *
-   * @param dataframe A tablesaw Table instance. tablesaw is an optional dependency, so this method is not typed.
+   * @param dataframe A tablesaw Table instance. tablesaw is an optional
+   *                  dependency, so this method is not typed.
    */
   public static TableComponent.Builder table(final @Nonnull Object dataframe) {
     try {
@@ -983,7 +1197,8 @@ public final class Jt {
         return tableFromArrayColumns(cols);
       }
     } catch (NoClassDefFoundError e) {
-      // TODO CYRIL add bom explanation once implemented - this error should only happen in embedded mode
+      // TODO CYRIL add bom explanation once implemented - this error should only
+      // happen in embedded mode
       throw new RuntimeException(
           "Could not load optional tablesaw dependency. If you wish to create tables from dataframe, make sure tablesaw is available in the classpath.",
           e);
@@ -998,7 +1213,9 @@ public final class Jt {
    * <p>
    * Examples:
    * Basic table with array of objects
-   * {@snippet file = "TableArrayApp.java" appUrl = "https://javelit-container-9siz-production.up.railway.app/" appHeight = "400"}
+   * {@snippet file = "TableArrayApp.java" appUrl =
+   * "https://javelit-container-9siz-production.up.railway.app/" appHeight =
+   * "400"}
    *
    * @param rows The array of objects representing table rows
    */
@@ -1011,11 +1228,15 @@ public final class Jt {
    * <p>
    * Examples:
    * Table from column arrays
-   * {@snippet file = "TableColumnsArrayApp.java" appUrl = "https://javelit-container-j1rl-production.up.railway.app/" appHeight = "400"}
+   * {@snippet file = "TableColumnsArrayApp.java" appUrl =
+   * "https://javelit-container-j1rl-production.up.railway.app/" appHeight =
+   * "400"}
    *
-   * @param cols A map where keys are column names and values are arrays of column data
+   * @param cols A map where keys are column names and values are arrays of column
+   *             data
    */
-  public static <E> TableComponent.Builder tableFromArrayColumns(final @Nonnull Map<@NotNull String, @NotNull E[]> cols) {
+  public static <E> TableComponent.Builder tableFromArrayColumns(
+      final @Nonnull Map<@NotNull String, @NotNull E[]> cols) {
     return TableComponent.Builder.ofColumnsArrays((Map) cols);
   }
 
@@ -1024,25 +1245,32 @@ public final class Jt {
    * <p>
    * Examples:
    * Table from column lists
-   * {@snippet file = "TableColumnsListApp.java" appUrl = "https://javelit-container-21w6-production.up.railway.app/" appHeight = "400"}
+   * {@snippet file = "TableColumnsListApp.java" appUrl =
+   * "https://javelit-container-21w6-production.up.railway.app/" appHeight =
+   * "400"}
    *
-   * @param cols A map where keys are column names and values are collections of column data
+   * @param cols A map where keys are column names and values are collections of
+   *             column data
    */
-  public static TableComponent.Builder tableFromListColumns(final @Nonnull Map<@NotNull String, @NotNull List<Object>> cols) {
+  public static TableComponent.Builder tableFromListColumns(
+      final @Nonnull Map<@NotNull String, @NotNull List<Object>> cols) {
     return TableComponent.Builder.ofColumnsLists(cols);
   }
-
 
   /**
    * Programmatically switch the current page in a multipage app.
    * <p>
-   * When {@code Jt.switchPage} is called, the current page execution stops and the specified page runs as if the
-   * user clicked on it in the sidebar navigation. The specified page must be recognized by Javelit's multipage
+   * When {@code Jt.switchPage} is called, the current page execution stops and
+   * the specified page runs as if the
+   * user clicked on it in the sidebar navigation. The specified page must be
+   * recognized by Javelit's multipage
    * architecture (your main app class or an app class in the available pages).
    * <p>
    * Examples:
    * Conditional page switching with checkboxes
-   * {@snippet file = "SwitchPageApp.java" appUrl = "https://javelit-container-wyfi-production.up.railway.app/" appHeight = "400"}
+   * {@snippet file = "SwitchPageApp.java" appUrl =
+   * "https://javelit-container-wyfi-production.up.railway.app/" appHeight =
+   * "400"}
    *
    * @param path The target page path. If {@code null}, target the home page.
    */
@@ -1050,25 +1278,30 @@ public final class Jt {
     // note: the design here is pretty hacky
     final NavigationComponent nav = StateManager.getNavigationComponent();
     checkState(nav != null,
-               "No navigation component found in app. switchPage only works with multipage app. Make sure switchPage is called after Jt.navigation().[...].use().");
+        "No navigation component found in app. switchPage only works with multipage app. Make sure switchPage is called after Jt.navigation().[...].use().");
     final JtPage newPage = nav.getPageFor(path);
     checkArgument(newPage != null, "Invalid page %s. This page is not registered in Jt.navigation().", path);
     final UrlContext urlContext = new UrlContext(newPage.urlPath(),
-                                                 Map.of());
+        Map.of());
     throw new BreakAndReloadAppException(sessionId -> StateManager.setUrlContext(sessionId, urlContext));
   }
 
   /**
    * Display an audio player.
    * <p>
-   * Javelit attempts to infer the format (MIME type) from  the input. If format inference fails, passing the format
+   * Javelit attempts to infer the format (MIME type) from the input. If format
+   * inference fails, passing the format
    * directly with {@code .format()} is necessary.
    * <p>
    * Examples:
    * Audio from external URL
-   * {@snippet file = "UrlAudioApp.java" appUrl = "https://javelit-container-agf8-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "UrlAudioApp.java" appUrl =
+   * "https://javelit-container-agf8-production.up.railway.app/" appHeight =
+   * "300"}
    * Audio from static resource
-   * {@snippet file = "staticUrlAudioApp/StaticUrlAudioApp.java" appUrl = "https://javelit-container-o7n6-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "staticUrlAudioApp/StaticUrlAudioApp.java" appUrl =
+   * "https://javelit-container-o7n6-production.up.railway.app/" appHeight =
+   * "300"}
    *
    * @param url A URL for a hosted audio file.
    */
@@ -1076,34 +1309,41 @@ public final class Jt {
     return new AudioComponent.Builder(url);
   }
 
-
   /**
    * Display a widget that returns an audio recording from the user's microphone.
    * <p>
    * Examples:
    * Record a voice message and play it back.
    * The default sample rate of 16000 Hz is optimal for speech recognition.
-   * {@snippet file = "AudioInputApp.java" appUrl = "https://javelit-container-oz84-production.up.railway.app" appHeight = "400"}
-   * Record high-fidelity audio and play it back. Higher sample rates can create higher-quality, larger audio files.
+   * {@snippet file = "AudioInputApp.java" appUrl =
+   * "https://javelit-container-oz84-production.up.railway.app" appHeight = "400"}
+   * Record high-fidelity audio and play it back. Higher sample rates can create
+   * higher-quality, larger audio files.
    * This might require a nicer microphone to fully appreciate the difference.
-   * {@snippet file = "HighQualityAudioInputApp.java" appUrl = "https://javelit-container-1en5-production.up.railway.app/" appHeight = "400"}
+   * {@snippet file = "HighQualityAudioInputApp.java" appUrl =
+   * "https://javelit-container-1en5-production.up.railway.app/" appHeight =
+   * "400"}
    *
-   * @param label A short label explaining to the user what this audio input widget is for. Markdown is supported, see {@link Jt#markdown(String)} for more details.
+   * @param label A short label explaining to the user what this audio input
+   *              widget is for. Markdown is supported, see
+   *              {@link Jt#markdown(String)} for more details.
    */
   public static AudioInputComponent.Builder audioInput(final @Nonnull String label) {
     return new AudioInputComponent.Builder(label);
   }
 
-
   /**
    * Display an audio player.
    * <p>
-   * Javelit attempts to infer the format (MIME type) from  the input. If format inference fails, passing the format
+   * Javelit attempts to infer the format (MIME type) from the input. If format
+   * inference fails, passing the format
    * directly with {@code .format()} is necessary.
    * <p>
    * Examples:
    * Audio from raw data
-   * {@snippet file = "RawDataAudioApp.java" appUrl = "https://javelit-container-xnj4-production.up.railway.app/" appHeight = "300"}
+   * {@snippet file = "RawDataAudioApp.java" appUrl =
+   * "https://javelit-container-xnj4-production.up.railway.app/" appHeight =
+   * "300"}
    *
    * @param data Raw audio data.
    */
@@ -1114,14 +1354,16 @@ public final class Jt {
   /**
    * Display an audio player.
    * <p>
-   * Javelit attempts to infer the format (MIME type) from  the input. If format inference fails, passing the format
+   * Javelit attempts to infer the format (MIME type) from the input. If format
+   * inference fails, passing the format
    * directly with {@code .format()} is necessary.
    * <p>
    * Examples:
    * Audio from local file
    * {@snippet file = "FileAudioApp.java"}
    *
-   * @param filePath A path to a local audio file. The path can be absolute or relative to the working directory.
+   * @param filePath A path to a local audio file. The path can be absolute or
+   *                 relative to the working directory.
    */
   public static AudioComponent.Builder audio(final @Nonnull Path filePath) {
     return new AudioComponent.Builder(filePath);
@@ -1130,7 +1372,8 @@ public final class Jt {
   /**
    * Display an audio player.
    * <p>
-   * Javelit attempts to infer the format (MIME type) from  the input. If format inference fails, passing the format
+   * Javelit attempts to infer the format (MIME type) from the input. If format
+   * inference fails, passing the format
    * directly with {@code .format()} is necessary.
    *
    * @param uploadedFile An uploaded file.
@@ -1145,9 +1388,13 @@ public final class Jt {
    * <p>
    * Examples:
    * Image from external URL
-   * {@snippet file = "UrlImageApp.java" appUrl = "https://javelit-container-sagw-production.up.railway.app/" appHeight = "700"}
+   * {@snippet file = "UrlImageApp.java" appUrl =
+   * "https://javelit-container-sagw-production.up.railway.app/" appHeight =
+   * "700"}
    * Image from static resource
-   * {@snippet file = "staticImageApp/StaticImageApp.java" appUrl = "https://javelit-container-o6qa-production.up.railway.app/" appHeight = "700"}
+   * {@snippet file = "staticImageApp/StaticImageApp.java" appUrl =
+   * "https://javelit-container-o6qa-production.up.railway.app/" appHeight =
+   * "700"}
    *
    * @param url A URL for a hosted image file.
    */
@@ -1160,7 +1407,8 @@ public final class Jt {
    * <p>
    * Examples:
    * Image from raw data
-   * {@snippet file = "ByteImageApp.java" appUrl = "https://javelit-container-jabg-production.up.railway.app" appHeight = "550"}
+   * {@snippet file = "ByteImageApp.java" appUrl =
+   * "https://javelit-container-jabg-production.up.railway.app" appHeight = "550"}
    *
    * @param data Raw image data.
    */
@@ -1175,7 +1423,8 @@ public final class Jt {
    * Image from local file
    * {@snippet file = "FileImageApp.java"}
    *
-   * @param filePath A path to a local image file. The path can be absolute or relative to the working directory.
+   * @param filePath A path to a local image file. The path can be absolute or
+   *                 relative to the working directory.
    */
   public static ImageComponent.Builder image(final @Nonnull Path filePath) {
     return ImageComponent.Builder.of(filePath);
@@ -1196,10 +1445,31 @@ public final class Jt {
    * <p>
    * Examples:
    * From an SVG image
-   * {@snippet file = "SvgImageApp.java" appUrl = "https://javelit-container-kkah-production.up.railway.app/" appHeight = "400"}
+   * {@snippet file = "SvgImageApp.java" appUrl =
+   * "https://javelit-container-kkah-production.up.railway.app/" appHeight =
+   * "400"}
    */
   public static ImageComponent.Builder imageFromSvg(final @Language("html") @Nonnull String svg) {
     return ImageComponent.Builder.ofSvg(svg);
+  }
+
+  /**
+   * Display an image from base64-encoded data.
+   * <p>
+   * This is useful when working with Gen AI services that return images as base64
+   * strings.
+   * <p>
+   * Examples:
+   * From a base64-encoded image
+   * {@snippet file = "Base64ImageApp.java" appUrl = "TODO" appHeight = "400"}
+   *
+   * @param base64Img A base64-encoded image string. May include the data URI
+   *                  prefix
+   *                  (e.g., "data:image/png;base64,...") or just the raw base64
+   *                  data.
+   */
+  public static ImageComponent.Builder imageFromBase64(final @Nonnull String base64Img) {
+    return ImageComponent.Builder.ofBase64(base64Img);
   }
 
   /**
@@ -1207,7 +1477,8 @@ public final class Jt {
    * <p>
    * Examples:
    * Display PDF from URL
-   * {@snippet file = "PdfApp.java" appUrl = "https://javelit-container-zhd-production.up.railway.app/" appHeight = "700"}
+   * {@snippet file = "PdfApp.java" appUrl =
+   * "https://javelit-container-zhd-production.up.railway.app/" appHeight = "700"}
    *
    * @param url A URL for a hosted PDF, or a path to a PDF in the static folder.
    */
@@ -1235,7 +1506,8 @@ public final class Jt {
    * PDF from local file
    * {@snippet file = "FilePdfApp.java"}
    *
-   * @param filePath A path to a local PDF file. The path can be absolute or relative to the working directory.
+   * @param filePath A path to a local PDF file. The path can be absolute or
+   *                 relative to the working directory.
    */
   public static PdfComponent.Builder pdf(final @Nonnull Path filePath) {
     return PdfComponent.Builder.of(filePath);
@@ -1253,15 +1525,21 @@ public final class Jt {
   /**
    * Rerun the script immediately.
    * <p>
-   * When {@code Jt.rerun()} is called, Javelit halts the current app run and executes no further statements. Javelit immediately
-   * queues the script to rerun. In a multipage app: by default, the rerun is for the same url path (same page). If the rerun could make
-   * the current page unavailable, pass {@code toHome = true} to send back to the home url and avoid 404 errors.
+   * When {@code Jt.rerun()} is called, Javelit halts the current app run and
+   * executes no further statements. Javelit immediately
+   * queues the script to rerun. In a multipage app: by default, the rerun is for
+   * the same url path (same page). If the rerun could make
+   * the current page unavailable, pass {@code toHome = true} to send back to the
+   * home url and avoid 404 errors.
    * <p>
    * Examples:
    * Updating session state and triggering rerun
-   * {@snippet file = "RerunApp.java" appUrl = "https://javelit-container-aopo-production.up.railway.app/" appHeight = "400"}
+   * {@snippet file = "RerunApp.java" appUrl =
+   * "https://javelit-container-aopo-production.up.railway.app/" appHeight =
+   * "400"}
    *
-   * @param toHome If {@code true}, rerun in {@code /} url path. If {@code false}, rerun in current path.
+   * @param toHome If {@code true}, rerun in {@code /} url path. If {@code false},
+   *               rerun in current path.
    */
   public static void rerun(final boolean toHome) {
     if (toHome) {
@@ -1275,9 +1553,12 @@ public final class Jt {
   /**
    * Rerun the script immediately.
    * <p>
-   * When {@code Jt.rerun()} is called, Javelit halts the current app run and executes no further statements. Javelit immediately
-   * queues the script to rerun. In a multipage app: by default, the rerun is for the same url path (same page). If the rerun could make
-   * the current page unavailable, pass {@code toHome = true} to send back to the home url and avoid 404 errors.
+   * When {@code Jt.rerun()} is called, Javelit halts the current app run and
+   * executes no further statements. Javelit immediately
+   * queues the script to rerun. In a multipage app: by default, the rerun is for
+   * the same url path (same page). If the rerun could make
+   * the current page unavailable, pass {@code toHome = true} to send back to the
+   * home url and avoid 404 errors.
    */
   public static void rerun() {
     Jt.rerun(false);

--- a/src/test/java/io/javelit/e2e/components/media/ImageComponentE2ETest.java
+++ b/src/test/java/io/javelit/e2e/components/media/ImageComponentE2ETest.java
@@ -37,18 +37,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ImageComponentE2ETest {
 
   @ParameterizedTest
-  @ValueSource(booleans = {false, true})
+  @ValueSource(booleans = { false, true })
   void testImageVariations(final boolean proxied, final TestInfo testInfo) {
     final JtRunnable app = () -> {
       // Test 1: Public URL
       Jt.image("https://raw.githubusercontent.com/javelit/public_assets/refs/heads/main/image/mountains2.jpg")
-        .caption("Mountain landscape from Unsplash")
-        .use();
+          .caption("Mountain landscape from Unsplash")
+          .use();
 
       // Test 2: Local file
       Jt.image(Path.of("examples/image/mountains.jpg"))
-        .caption("Mountains from local file")
-        .use();
+          .caption("Mountains from local file")
+          .use();
 
       // Test 3: SVG
       String svg = """
@@ -58,37 +58,43 @@ public class ImageComponentE2ETest {
           </svg>
           """;
       Jt.imageFromSvg(svg)
-        .caption("Simple SVG checkmark icon")
-        .use();
+          .caption("Simple SVG checkmark icon")
+          .use();
 
       // Test 4: Caption with markdown
       Jt.image("https://raw.githubusercontent.com/javelit/public_assets/refs/heads/main/image/mountains2.jpg")
-        .caption("**Beautiful mountains** in *stunning* detail. [Learn more](https://unsplash.com)")
-        .use();
+          .caption("**Beautiful mountains** in *stunning* detail. [Learn more](https://unsplash.com)")
+          .use();
 
       // Test 5: Width content
       Jt.image("https://raw.githubusercontent.com/javelit/public_assets/refs/heads/main/image/mountains2.jpg")
-        .width("content")
-        .caption("Content width (natural size)")
-        .use();
+          .width("content")
+          .caption("Content width (natural size)")
+          .use();
 
       // Test 6: Width stretch
       Jt.image("https://raw.githubusercontent.com/javelit/public_assets/refs/heads/main/image/mountains2.jpg")
-        .width("stretch")
-        .caption("Stretched to full width")
-        .use();
+          .width("stretch")
+          .caption("Stretched to full width")
+          .use();
 
       // Test 7: Width pixels
       Jt.image("https://raw.githubusercontent.com/javelit/public_assets/refs/heads/main/image/mountains2.jpg")
-        .width(400)
-        .caption("Fixed width: 400px")
-        .use();
+          .width(400)
+          .caption("Fixed width: 400px")
+          .use();
+
+      // Test 8: Base64 image
+      String base64Png = "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mP8z8DwHwYYGBgYBhBHAQBVhQOBMN0vkwAAAABJRU5ErkJggg==";
+      Jt.imageFromBase64(base64Png)
+          .caption("Image from base64")
+          .use();
     };
 
     PlaywrightUtils.runInBrowser(testInfo, app, true, proxied, page -> {
       final String pathPrefix = proxied ? TEST_PROXY_PREFIX : "";
 
-      // Verify all 7 image components are rendered
+      // Verify all 8 image components are rendered
       assertThat(page.locator("#app jt-image").nth(0)).isVisible(WAIT_1_SEC_MAX);
       assertThat(page.locator("#app jt-image").nth(1)).isVisible(WAIT_1_SEC_MAX);
       assertThat(page.locator("#app jt-image").nth(2)).isVisible(WAIT_1_SEC_MAX);
@@ -96,37 +102,38 @@ public class ImageComponentE2ETest {
       assertThat(page.locator("#app jt-image").nth(4)).isVisible(WAIT_1_SEC_MAX);
       assertThat(page.locator("#app jt-image").nth(5)).isVisible(WAIT_1_SEC_MAX);
       assertThat(page.locator("#app jt-image").nth(6)).isVisible(WAIT_1_SEC_MAX);
+      assertThat(page.locator("#app jt-image").nth(7)).isVisible(WAIT_1_SEC_MAX);
 
       // Test 1: Public URL
       assertThat(page.locator("#app jt-image").nth(0).locator("img")).isVisible(WAIT_1_SEC_MAX);
       String src1 = page.locator("#app jt-image").nth(0).locator("img").getAttribute("src");
       assertTrue(src1.contains("mountains2.jpg"), "Image src should contain mountains2.jpg, got: " + src1);
       assertThat(page.locator("#app jt-image").nth(0).locator(".caption")).hasText("Mountain landscape from Unsplash",
-                                                                                   WAIT_1_SEC_MAX_TEXT);
+          WAIT_1_SEC_MAX_TEXT);
 
       // Test 2: Local file
       assertThat(page.locator("#app jt-image").nth(1).locator("img")).isVisible(WAIT_1_SEC_MAX);
       String src2 = page.locator("#app jt-image").nth(1).locator("img").getAttribute("src");
       assertTrue(src2.startsWith(pathPrefix + "/_/media/"),
-                 "Image src should start with " + pathPrefix + "/_/media/, got: " + src2);
+          "Image src should start with " + pathPrefix + "/_/media/, got: " + src2);
       assertThat(page.locator("#app jt-image").nth(1).locator(".caption")).hasText("Mountains from local file",
-                                                                                   WAIT_1_SEC_MAX_TEXT);
+          WAIT_1_SEC_MAX_TEXT);
 
       // Test 3: SVG
       assertThat(page.locator("#app jt-image").nth(2).locator("img")).isVisible(WAIT_1_SEC_MAX);
       String src3 = page.locator("#app jt-image").nth(2).locator("img").getAttribute("src");
       assertTrue(src3.startsWith("data:image/svg+xml,"), "Image src should be SVG data URI, got: " + src3);
       assertThat(page.locator("#app jt-image").nth(2).locator(".caption")).hasText("Simple SVG checkmark icon",
-                                                                                   WAIT_1_SEC_MAX_TEXT);
+          WAIT_1_SEC_MAX_TEXT);
 
       // Test 4: Caption with markdown
       assertThat(page.locator("#app jt-image").nth(3).locator(".caption strong")).hasText("Beautiful mountains",
-                                                                                          WAIT_1_SEC_MAX_TEXT);
+          WAIT_1_SEC_MAX_TEXT);
       assertThat(page.locator("#app jt-image").nth(3).locator(".caption em")).hasText("stunning", WAIT_1_SEC_MAX_TEXT);
       assertThat(page.locator("#app jt-image").nth(3).locator(".caption a")).hasText("Learn more", WAIT_1_SEC_MAX_TEXT);
       assertThat(page.locator("#app jt-image").nth(3).locator(".caption a")).hasAttribute("href",
-                                                                                          "https://unsplash.com",
-                                                                                          WAIT_1_SEC_MAX_ATTRIBUTE);
+          "https://unsplash.com",
+          WAIT_1_SEC_MAX_ATTRIBUTE);
 
       // Test 5: Width content
       assertThat(page.locator("#app jt-image").nth(4)).hasAttribute("width", "content", WAIT_1_SEC_MAX_ATTRIBUTE);
@@ -136,11 +143,18 @@ public class ImageComponentE2ETest {
 
       // Test 7: Width pixels
       assertThat(page.locator("#app jt-image").nth(6)).hasAttribute("width", "400", WAIT_1_SEC_MAX_ATTRIBUTE);
+
+      // Test 8: Base64 image
+      assertThat(page.locator("#app jt-image").nth(7).locator("img")).isVisible(WAIT_1_SEC_MAX);
+      String src8 = page.locator("#app jt-image").nth(7).locator("img").getAttribute("src");
+      assertTrue(src8.startsWith("data:image/png;base64,"), "Image src should be base64 data URI, got: " + src8);
+      assertThat(page.locator("#app jt-image").nth(7).locator(".caption")).hasText("Image from base64",
+          WAIT_1_SEC_MAX_TEXT);
     });
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {false, true})
+  @ValueSource(booleans = { false, true })
   void testStaticFolder(final boolean proxied, final TestInfo testInfo) throws IOException {
     final Path tempDir = Files.createTempDirectory("javelit-image-test-");
     copyResourceDirectory("image-test", tempDir);
@@ -160,19 +174,19 @@ public class ImageComponentE2ETest {
 
       // Verify src points to static folder
       assertThat(page.locator("#app jt-image img")).hasAttribute("src",
-                                                                 pathPrefix + "app/static/mountains.jpg",
-                                                                 WAIT_1_SEC_MAX_ATTRIBUTE);
+          pathPrefix + "app/static/mountains.jpg",
+          WAIT_1_SEC_MAX_ATTRIBUTE);
     });
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {false, true})
+  @ValueSource(booleans = { false, true })
   void testGeneratedBytes(final boolean proxied, final TestInfo testInfo) {
     final JtRunnable app = () -> {
       byte[] imageBytes = Files.readAllBytes(Path.of("examples/image/mountains.jpg"));
       Jt.image(imageBytes)
-        .caption("Programmatically generated hexagon (800x400)")
-        .use();
+          .caption("Programmatically generated hexagon (800x400)")
+          .use();
     };
 
     // Verify image component is rendered
@@ -191,11 +205,11 @@ public class ImageComponentE2ETest {
       // Verify src contains media hash (starts with /_/media/)
       String src = page.locator("#app jt-image img").getAttribute("src");
       assertTrue(src.startsWith(pathPrefix + "/_/media/"),
-                 "Image src should start with " + pathPrefix + "/_/media/, got: " + src);
+          "Image src should start with " + pathPrefix + "/_/media/, got: " + src);
 
       // Verify caption
       assertThat(page.locator("#app jt-image .caption")).hasText("Programmatically generated hexagon (800x400)",
-                                                                 WAIT_1_SEC_MAX_TEXT);
+          WAIT_1_SEC_MAX_TEXT);
     });
   }
 }


### PR DESCRIPTION
## Summary
Adds `Jt.imageFromBase64(String base64Img)` method to support displaying images directly from base64-encoded strings.

Fixes #55

## Changes
- **ImageComponent.java**: Added [convertBase64ToUrl()](cci:1://file:///home/utsav/.gemini/antigravity/playground/glowing-hawking/src/main/java/io/javelit/components/media/ImageComponent.java:85:2-93:3) method and [ofBase64()](cci:1://file:///home/utsav/.gemini/antigravity/playground/glowing-hawking/src/main/java/io/javelit/components/media/ImageComponent.java:148:4-150:5) factory
- **Jt.java**: Added [imageFromBase64()](cci:1://file:///home/utsav/.gemini/antigravity/playground/glowing-hawking/src/main/java/io/javelit/core/Jt.java:1455:2-1472:3) API method with Javadoc
- **Base64ImageApp.java**: Demo app for documentation
- **ImageComponentE2ETest.java**: Added test case for base64 images

## Usage
```java
// From Gen AI service response
String base64Png = "iVBORw0KGgoAAAANSUhEUgAAAAo...";
Jt.imageFromBase64(base64Png).caption("AI-generated image").use();

// With data URI prefix (also supported)
String withPrefix = "data:image/png;base64,...";
Jt.imageFromBase64(withPrefix).use();