### PR TITLE
feat: allow to modify target attribute of external pageLink

### DIFF
--- a/src/main/java/io/javelit/components/multipage/PageLinkComponent.java
+++ b/src/main/java/io/javelit/components/multipage/PageLinkComponent.java
@@ -37,6 +37,7 @@ public final class PageLinkComponent extends JtComponent<JtComponent.NONE> {
   final @Nonnull String label;
   final @Nonnull String url;
   final boolean isExternal;
+  final String target;
   final String icon;
   final String help;
   final boolean disabled;
@@ -60,6 +61,7 @@ public final class PageLinkComponent extends JtComponent<JtComponent.NONE> {
     this.label = markdownToHtml(builder.label, true);
     this.url = builder.url;
     this.isExternal = builder.isExternal;
+    this.target = builder.target;
     this.icon = builder.icon;
     this.help = builder.help;
     this.disabled = builder.disabled;
@@ -84,6 +86,7 @@ public final class PageLinkComponent extends JtComponent<JtComponent.NONE> {
     private String icon;
     private String help;
     private boolean disabled;
+    private String target = "_blank";
     private String width = "content"; // content, stretch, or pixel value
 
     // Constructor for internal page links
@@ -169,6 +172,15 @@ public final class PageLinkComponent extends JtComponent<JtComponent.NONE> {
         throw new IllegalArgumentException("Width in pixels must be non-negative. Got: " + widthPixels);
       }
       this.width = String.valueOf(widthPixels);
+      return this;
+    }
+
+    /**
+     * The target of the link. Use {@code "_blank"} to open in a new tab, {@code "_self"} to open in the same tab, or a custom target.
+     */
+    public Builder target(final @Nonnull String target) {
+      checkArgument(!target.isBlank(), "Target cannot be null or empty");
+      this.target = target;
       return this;
     }
 

--- a/src/main/resources/components/multipage/PageLinkComponent.register.html.mustache
+++ b/src/main/resources/components/multipage/PageLinkComponent.register.html.mustache
@@ -141,6 +141,7 @@
             label: {type: String},
             url: {type: String},
             isExternal: {type: Boolean, attribute: 'is-external'},
+            target: {type: String},
             icon: {type: String},
             help: {type: String},
             disabled: {type: Boolean},
@@ -155,6 +156,7 @@
             this.disabled = false;
             this.width = 'content';
             this.isActive = false;
+            this.target = '_blank';
         }
 
         isEmoji(str) {
@@ -245,7 +247,7 @@
                     html`<a
                             class="${linkClass}"
                             href="${this.url}"
-                            target="_blank"
+                            target="${this.target}"
                             rel="noopener noreferrer"
                             style="${widthStyle}"
                             @click="${this.handleClick}">

--- a/src/main/resources/components/multipage/PageLinkComponent.render.html.mustache
+++ b/src/main/resources/components/multipage/PageLinkComponent.render.html.mustache
@@ -17,6 +17,7 @@
         component-key="{{getInternalKey}}"
         label="{{label}}"
         {{#url}}url="{{url}}"{{/url}}
+        target="{{target}}"
     {{#isExternal}}is-external{{/isExternal}}
     {{#icon}}icon="{{icon}}"{{/icon}}
     {{#help}}help="{{help}}"{{/help}}

--- a/src/test/java/io/javelit/e2e/components/multipage/PageLinkComponentE2ETest.java
+++ b/src/test/java/io/javelit/e2e/components/multipage/PageLinkComponentE2ETest.java
@@ -57,6 +57,9 @@ public class PageLinkComponentE2ETest {
       // External link
       Jt.pageLink("https://example.com", "External Link").icon("🌐").use();
 
+      // External link
+      Jt.pageLink("https://example.target.com", "External Self Link").icon("🌐").target("_self").use();
+
       // Disabled link
       Jt.pageLink("/about").disabled(true).use();
     };
@@ -99,6 +102,12 @@ public class PageLinkComponentE2ETest {
       assertThat(page.getByRole(AriaRole.LINK).filter(new Locator.FilterOptions().setHasText("External Link")))
           .hasAttribute("target", "_blank");
 
+      // Test external link has correct attributes
+      assertThat(page.getByRole(AriaRole.LINK).filter(new Locator.FilterOptions().setHasText("External Self Link")))
+          .hasAttribute("href", "https://example.target.com");
+      assertThat(page.getByRole(AriaRole.LINK).filter(new Locator.FilterOptions().setHasText("External Self Link")))
+          .hasAttribute("target", "_self");
+
       // Test disabled link
       assertThat(page.locator("jt-page-link[disabled]")).isVisible(WAIT_1_SEC_MAX);
     });
@@ -113,6 +122,8 @@ public class PageLinkComponentE2ETest {
     Jt.text("About page content").use();
     Jt.pageLink("/home").use();
   }
+
+
 
   @ParameterizedTest
   @ValueSource(booleans = {false, true})


### PR DESCRIPTION
Hello,

I am adding Microsoft 365 authentication to my javelit application, and I need the login page to open on the same page.
So I add this PR to give the possibility to change the target from external link.

Thank you.